### PR TITLE
support compiling apps

### DIFF
--- a/scripts/download.ts
+++ b/scripts/download.ts
@@ -7,4 +7,5 @@ switch (process.platform) {
 
 async function dl(filename: string) {
     await Bun.$`curl -sSLo "${import.meta.dir}/../build/${filename}" "https://github.com/tr1ckydev/webview-bun/releases/latest/download/${filename}"`.nothrow();
+    await Bun.$`ln -s ${filename} ${import.meta.dir}/../build/libwebview.bin`.nothrow();
 }

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,5 +1,6 @@
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import { Webview } from "./webview";
+import bin from "../build/libwebview.bin";
 
 export function encodeCString(value: string) {
     return ptr(new TextEncoder().encode(value + "\0"));
@@ -16,16 +17,7 @@ export function unload() {
     lib.close();
 }
 
-let lib_path = `${import.meta.dir}/../build/`;
-
-switch (process.platform) {
-    case "win32": lib_path += "libwebview.dll"; break;
-    case "linux": lib_path += "libwebview.so"; break;
-    case "darwin": lib_path += `libwebview.${process.arch}.dylib`; break;
-    default: throw "unsupported platform: " + process.platform;
-}
-
-export const lib = dlopen(process.env.WEBVIEW_PATH ?? lib_path, {
+export const lib = dlopen(process.env.WEBVIEW_PATH ?? Bun.file(bin), {
     webview_create: {
         args: [FFIType.i32, FFIType.ptr],
         returns: FFIType.ptr


### PR DESCRIPTION
Hi, this pull request allows you to compile apps with `webview-bun` by embedding the library directly into the app.

This only works if the import is statically analyzable during compilation, which hasn't been the case thus far. I solved this by creating a symlink to the downloaded library that is called the same way on every platform.

Not tested on Mac/Windows.

This solves #6.