### PR TITLE
add debian build dependency to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Webview is a tiny cross-platform library to make **web-based GUIs for desktop ap
 
   > To use a different version, see Development section below.
 
-  - Debian-based systems: `apt install libgtk-4-1 libwebkitgtk-6.0-4`
+  - Debian-based systems: `apt install libgtk-4-1 libwebkitgtk-6.0-4 libwebkitgtk-6.0-dev`
   - Arch-based systems: `yay -S gtk4 webkitgtk-6.0`
   - Fedora-based systems: `dnf install gtk4 webkitgtk6.0`
 </details>


### PR DESCRIPTION
After your recent changes to the build script, on Debian 12, I also had to install `libwebkitgtk-6.0-dev` for compilation to succeed.